### PR TITLE
Replace deprecated torch.range in hy3dgen/texgen/hunyuanpaint/pipeline.py with torch.arange

### DIFF
--- a/hy3dgen/texgen/hunyuanpaint/pipeline.py
+++ b/hy3dgen/texgen/hunyuanpaint/pipeline.py
@@ -595,7 +595,7 @@ class HunyuanPaintPipeline(StableDiffusionPipeline):
         if self.is_turbo:
             bsz = 3
             N_gen = 15
-            index = torch.range(29, 0, -bsz, device='cuda').long()
+            index = torch.arange(29, -1, -bsz, device='cuda').long()
             timesteps = self.solver.ddim_timesteps[index]
             self.scheduler.set_timesteps(timesteps=timesteps.cpu(), device='cuda')
         else:


### PR DESCRIPTION
Fix #374

## Summary

Replaces the deprecated `torch.range` in `hy3dgen/texgen/hunyuanpaint/pipeline.py:598` with the equivalent `torch.arange`.

`torch.range` emits a `UserWarning` on every call (verified on torch 2.11.0):

> torch.range is deprecated and will be removed in a future release because its behavior is inconsistent with Python's range builtin. Instead, use torch.arange, which produces values in [start, end).

This is the only `torch.range` usage in the repo; it runs in the turbo path of the paint pipeline on every generation. The warning was previously reported by a user in #270 (patched locally, no maintainer response).

## Changes

- `hy3dgen/texgen/hunyuanpaint/pipeline.py:598`: `torch.range(29, 0, -bsz, device='cuda').long()` → `torch.arange(29, -1, -bsz, device='cuda').long()`

(`torch.range` is end-inclusive — `torch.range(29, 0, -3)` produces `[29, 26, …, 2]`; `torch.arange` uses an open interval, so the end is `-1` = last value `2` + step `-3`. `torch.arange` with integer inputs returns `int64`, so the explicit `.long()` is a no-op — kept to match the surrounding style.)

## Validation (torch 2.11.0+cpu)

- `torch.equal(torch.range(29, 0, -b), torch.arange(29, -1, -b))` → `True` for bsz ∈ {2, 3, 5} — identical values, end-inclusive semantics preserved.
- With `warnings.simplefilter("error", UserWarning)`: the current line raises the deprecation `UserWarning`; `torch.arange` constructs cleanly.

## Dependency note

No dependency constraints involved: `requirements.txt` declares `torch` without any version bound, and `setup.py`'s `install_requires` does not include torch. The deprecation warning is emitted on all torch versions.